### PR TITLE
Pin jackson to 2.22.0 for Dependabot alerts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,11 @@ patch-cve-2025-48924 = { module = "org.apache.commons:commons-lang3", version = 
 # Security patches - Other
 patch-cve-2022-45868 = { module = "com.h2database:h2", version = { strictly = "[2.2.220,)", prefer = "2.2.220" } }
 patch-cve-2025-4949 = { module = "org.eclipse.jgit:org.eclipse.jgit", version = { strictly = "[6.10.1.202505221210-r,)", prefer = "6.10.1.202505221210-r" } }
-patch-ghsa-72hv-8253-57qq = { module = "com.fasterxml.jackson.core:jackson-core", version = { strictly = "[2.21.1,)", prefer = "2.21.1" } }
+# jackson 2.22.0: core fixes GHSA-72hv-8253-57qq; databind fixes GHSA-5jmj-h7xm-6q6v plus
+# the 2.21.4 advisories (5hh8, 9fxm, hgj6, rmj7, j3rv, rcqc). 2.21.5 was never published, and
+# the stack is kept aligned to avoid mixing core/databind across the 2.21/2.22 boundary.
+patch-ghsa-72hv-8253-57qq = { module = "com.fasterxml.jackson.core:jackson-core", version = { strictly = "[2.22.0,)", prefer = "2.22.0" } }
+patch-ghsa-5jmj-h7xm-6q6v = { module = "com.fasterxml.jackson.core:jackson-databind", version = { strictly = "[2.22.0,)", prefer = "2.22.0" } }
 
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version.ref = "servlet-api" }
@@ -41,7 +45,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 
 [bundles]
-security-patches = ["patch-cve-2022-45868", "patch-cve-2025-4949", "patch-cve-2025-48734", "patch-cve-2025-48924", "patch-cve-2026-5598-bcpg", "patch-cve-2026-5598-bcprov", "patch-ghsa-72hv-8253-57qq"]
+security-patches = ["patch-cve-2022-45868", "patch-cve-2025-4949", "patch-cve-2025-48734", "patch-cve-2025-48924", "patch-cve-2026-5598-bcpg", "patch-cve-2026-5598-bcprov", "patch-ghsa-72hv-8253-57qq", "patch-ghsa-5jmj-h7xm-6q6v"]
 mockito = ["mockito-core", "mockito-junit-jupiter"]
 
 [plugins]


### PR DESCRIPTION
## Summary

Resolves the open Dependabot alerts against `com.fasterxml.jackson.core:jackson-databind` on the **buildscript classpath** (pulled in transitively by the OWASP dependency-check plugin via `settings.gradle`).

## Why 2.22.0 and not 2.21.4

Most alerts are fixed by 2.21.4, but GHSA-5jmj-h7xm-6q6v lists **2.21.5** as the fix — and 2.21.5 was never published (the 2.21.x line ends at 2.21.4). The first published version covering all of them is **2.22.0**.

Both `jackson-core` and `jackson-databind` are pinned to 2.22.0 to keep the jackson stack aligned, following the existing `security-patches` bundle pattern. These are build-tooling dependencies only — they do not affect the published artifact's runtime.

## Verification
- `./gradlew buildEnvironment` confirms both force to 2.22.0 on the buildscript classpath.
- `./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)