### PR TITLE
Inject security patches as buildscript constraints, not dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,15 @@ gradle.beforeProject { proj ->
         tomlFile.eachLine { line ->
             def matcher = line =~ /^patch-[a-z0-9-]+ = \{ module = "([^"]+)", version = \{ strictly = "[^"]+", prefer = "([^"]+)"/
             if (matcher) {
-                proj.buildscript.dependencies.add('classpath', "${matcher[0][1]}:${matcher[0][2]}")
+                def module = matcher[0][1]
+                def patchVersion = matcher[0][2]
+                // Constraint, not a dependency: forces the patched floor only when the module is
+                // already on the buildscript classpath; never adds new deps (app-only patches apply
+                // as implementation constraints in build.gradle instead).
+                proj.buildscript.dependencies.constraints.add('classpath', module) {
+                    version { require "[${patchVersion},)"; prefer patchVersion }
+                    because 'transitive security patch'
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

The `settings.gradle` buildscript injector previously added each `patch-*` entry as a real **dependency** (`buildscript.dependencies.add('classpath', ...)`). That pulls the module *and its whole transitive tree* onto the buildscript classpath even when nothing else uses it — so app-framework patches (e.g. `spring-kafka`, `tomcat-embed-*`) leaked onto the build tooling classpath.

This switches to a dependency **constraint**:

```groovy
proj.buildscript.dependencies.constraints.add('classpath', module) {
    version { require "[${patchVersion},)"; prefer patchVersion }
    because 'transitive security patch'
}
```

A constraint only takes effect when the module is **already present** on the buildscript classpath. So it:
- **forces** the patched floor for genuine build-tooling transitives (jackson, bcprov, commons, h2, jgit, …),
- **never adds** modules that weren't there (app-only patches now no-op here; they still apply as `implementation` constraints in `build.gradle`),
- **never downgrades** deps already resolving higher — `require "[X,)"` is "≥ X", so e.g. jgit stays 7.7.0 instead of dropping to the 6.10.1 floor.

No catalog or version values changed.

## Verification
- `./gradlew buildEnvironment` confirms jackson still forced to the patched versions; app-only patches no longer appear on the buildscript classpath; no downgrades.
- `./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)